### PR TITLE
Prefer gated entries per group

### DIFF
--- a/emikoscript.js
+++ b/emikoscript.js
@@ -454,7 +454,10 @@ function onUserMessage(userText, api){
   }
   const resolved = [...singles];
   for (const [g, arr] of groups.entries()){
-    resolved.push(arr[0]); // pick first per group
+    const maxGate = arr.reduce((m, item) => Math.max(m, item.minMessages || 0), -Infinity);
+    const gated = arr.filter(item => (item.minMessages || 0) === maxGate);
+    const chosen = gated[Math.floor(Math.random() * gated.length)] || arr[0];
+    resolved.push(chosen);
   }
 
   injectResolved(resolved, api);


### PR DESCRIPTION
## Summary
- adjust group resolution to choose the highest unlocked entry instead of always the first
- fall back to random selection among equally gated entries to rotate surfaced lore beats

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2e65cfed08324b748e949d2f026a9