### PR TITLE
Allow Nerys reveal during settle mode

### DIFF
--- a/TessaJS.js
+++ b/TessaJS.js
@@ -269,7 +269,10 @@ function detectIntent(u){
 function gateRevealFor(topic){
   if (CONF.style.oneRevealPerReply && S.reveals >= 1) return false;
   if (S.mode === "investigate") { S.reveals++; markFire("reveal"); return true; }
-  if (S.mode === "settle" && topic === "rings") { S.reveals++; markFire("reveal"); return true; }
+  if (S.mode === "settle") {
+    if (topic === "rings") { S.reveals++; markFire("reveal"); return true; }
+    if (topic === "nerys") { S.reveals++; markFire("reveal"); return true; }
+  }
   return false;
 }
 
@@ -400,7 +403,7 @@ function planReply(userText, turnIndex){
   }
 
   let intent = detectIntent(usr);
-  if (S.mode === "settle" && (intent === "rings" || intent === "journal")) S.mode = "investigate";
+  if (S.mode === "settle" && (intent === "rings" || intent === "journal" || intent === "nerys")) S.mode = "investigate";
   S.lastIntent = intent;
 
   if (isCoop(usr)) S.coopStreak++; else S.coopStreak = 0;


### PR DESCRIPTION
## Summary
- allow the Nerys reveal gate to fire even when the state machine is in settle mode
- promote the scene mode to investigate when the detected intent targets Nerys so future turns stay aligned

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daf48e28bc832489547625b7bf3299